### PR TITLE
Enable announce option on swarm

### DIFF
--- a/packages/core/lib/dat.ts
+++ b/packages/core/lib/dat.ts
@@ -1,7 +1,7 @@
 import { IDat, ISwarmable } from '@sammacbeth/dat-types/lib/dat';
 import { IHyperdrive } from '@sammacbeth/dat-types/lib/hyperdrive';
 import { IReplicableBase } from '@sammacbeth/dat-types/lib/replicable';
-import ISwarm from '@sammacbeth/dat-types/lib/swarm';
+import ISwarm, { JoinSwarmOptions } from '@sammacbeth/dat-types/lib/swarm';
 import { EventEmitter } from 'events';
 
 export default class Dat<D extends IHyperdrive & IReplicableBase> extends EventEmitter
@@ -38,8 +38,8 @@ export default class Dat<D extends IHyperdrive & IReplicableBase> extends EventE
     return this.drive.writable;
   }
 
-  public async joinSwarm() {
-    this.swarm.add(this.drive);
+  public async joinSwarm(options?: JoinSwarmOptions) {
+    this.swarm.add(this.drive, options);
     this.emit('join');
     this.isSwarming = true;
 

--- a/packages/dat1/test/api.test.ts
+++ b/packages/dat1/test/api.test.ts
@@ -113,6 +113,7 @@ describe('HyperdriveAPI', function() {
       });
       expect(dir).to.have.length(1);
       expect(dir).to.contain('test');
+      datRemote.close();
     });
 
     it('download: disables data download', async () => {
@@ -123,7 +124,10 @@ describe('HyperdriveAPI', function() {
       const datRemote = await api.getDat(datOriginal.drive.key.toString('hex'), { persist: false, download: false });
       await new Promise((resolve, reject) => {
         datRemote.ready.then(() => reject('should not be ready'));
-        setTimeout(() => resolve(), 300);
+        setTimeout(() => {
+          resolve()
+          datRemote.close();
+        }, 300);
       });
     });
   })

--- a/packages/dat1/test/api.test.ts
+++ b/packages/dat1/test/api.test.ts
@@ -50,7 +50,6 @@ describe('HyperdriveAPI', function() {
         }
       });
     });
-    const swarm: any = api.loader.swarm;
   });
 
   describe('persist', () => {

--- a/packages/dat1/test/api.test.ts
+++ b/packages/dat1/test/api.test.ts
@@ -21,6 +21,7 @@ describe('HyperdriveAPI', function() {
         deletedSet.add(key);
         return Promise.resolve();
       },
+      autoListen: false,
     });
   });
 
@@ -49,6 +50,7 @@ describe('HyperdriveAPI', function() {
         }
       });
     });
+    const swarm: any = api.loader.swarm;
   });
 
   describe('persist', () => {
@@ -69,6 +71,16 @@ describe('HyperdriveAPI', function() {
       await api.deleteDatData(addr);
       expect(deletedSet).to.have.length(1);
       expect(deletedSet).to.contain(addr);
+    });
+  });
+
+  describe('Swarm options', () => {
+    it('load dat without announcing', async () => {
+      const dat = await api.getDat(datAddr, { autoSwarm: true, persist: false, announce: false });
+      await dat.ready;
+      const swarm: any = api.loader.swarm;
+      const addr: string = Object.keys(swarm.disc._swarm._discovery._announcing)[0];
+      expect(addr.endsWith(':0')).to.be.true;
     });
   });
 });

--- a/packages/dat1/test/api.test.ts
+++ b/packages/dat1/test/api.test.ts
@@ -80,7 +80,8 @@ describe('HyperdriveAPI', function() {
       await dat.ready;
       const swarm: any = api.loader.swarm;
       const addr: string = Object.keys(swarm.disc._swarm._discovery._announcing)[0];
-      expect(addr.endsWith(':0')).to.be.true;
+      const port = addr.split(':')[1]
+      expect(port).to.be.eql('0');
     });
   });
 });

--- a/packages/dat1wrtc/test/api.test.ts
+++ b/packages/dat1wrtc/test/api.test.ts
@@ -2,12 +2,12 @@ import { expect } from 'chai';
 import 'mocha';
 import apiFactory, { DatV1API } from '../';
 
-describe('HyperdriveAPI', function () {
+describe('HyperdriveAPI', function() {
   this.timeout(10000);
 
   const datAddr = '41f8a987cfeba80a037e51cc8357d513b62514de36f2f9b3d3eeec7a8fb3b5a5';
   let api: DatV1API;
-  
+
   beforeEach(() => {
     api = apiFactory();
   });
@@ -36,4 +36,15 @@ describe('HyperdriveAPI', function () {
       });
     });
   });
-})
+
+  describe('Swarm options', () => {
+    it('load dat without announcing', async () => {
+      const dat = await api.getDat(datAddr, { autoSwarm: true, persist: false, announce: false });
+      await dat.ready;
+      const swarm: any = api.loader.swarm;
+      const addr: string = Object.keys(swarm.disc._swarm._discovery._announcing)[0];
+      const port = addr.split(':')[1];
+      expect(port).to.be.eql('0');
+    });
+  });
+});

--- a/packages/network-hyperdiscovery/lib/hyperdiscovery.ts
+++ b/packages/network-hyperdiscovery/lib/hyperdiscovery.ts
@@ -1,5 +1,5 @@
 import { IReplicable } from '@sammacbeth/dat-types/lib/replicable';
-import ISwarm from '@sammacbeth/dat-types/lib/swarm';
+import ISwarm, { JoinSwarmOptions } from '@sammacbeth/dat-types/lib/swarm';
 import { EventEmitter } from 'events';
 import Discovery = require('hyperdiscovery');
 
@@ -10,6 +10,8 @@ export type DiscoveryOptions = {
   tcp?: any;
   dht?: any;
   autoListen?: boolean;
+  upload?: boolean;
+  download?: boolean;
 };
 
 export default class HyperDiscovery<T extends IReplicable> extends EventEmitter
@@ -37,8 +39,8 @@ export default class HyperDiscovery<T extends IReplicable> extends EventEmitter
     });
   }
 
-  public add(feed: IReplicable) {
-    this.disc.add(feed);
+  public add(feed: IReplicable, options?: JoinSwarmOptions) {
+    this.disc.add(feed, options);
   }
 
   public remove(feed: IReplicable) {

--- a/packages/network-hyperdiscovery/package.json
+++ b/packages/network-hyperdiscovery/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@sammacbeth/dat-types": "^0.1.0",
-    "hyperdiscovery": "git+https://git@github.com/datproject/hyperdiscovery.git#235a19ef14a8ca702c801f855c6281baa65f9bb4"
+    "hyperdiscovery": "git+https://git@github.com/sammacbeth/hyperdiscovery.git#39cff7f"
   },
   "devDependencies": {
     "tslint": "^5.20.1",

--- a/packages/network-hyperdiscovery/package.json
+++ b/packages/network-hyperdiscovery/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@sammacbeth/dat-types": "^0.1.0",
-    "hyperdiscovery": "^10.2.1"
+    "hyperdiscovery": "git+https://git@github.com/datproject/hyperdiscovery.git#235a19ef14a8ca702c801f855c6281baa65f9bb4"
   },
   "devDependencies": {
     "tslint": "^5.20.1",

--- a/packages/network-hyperwebrtc/lib/hyperwebrtc.ts
+++ b/packages/network-hyperwebrtc/lib/hyperwebrtc.ts
@@ -1,6 +1,7 @@
 import WRTCDiscovery = require('@geut/discovery-swarm-webrtc');
 import HyperDiscovery, { DiscoveryOptions } from '@sammacbeth/dat-network-hyperdiscovery';
 import { IReplicable } from '@sammacbeth/dat-types/lib/replicable';
+import { JoinSwarmOptions } from '@sammacbeth/dat-types/lib/swarm';
 
 export type WRTCDiscoveryOptions = {
   id?: Buffer;
@@ -31,8 +32,8 @@ export default class HyperWebRTC<T extends IReplicable> extends HyperDiscovery<T
     });
   }
 
-  public add(feed: IReplicable) {
-    this.disc.add(feed);
+  public add(feed: IReplicable, options?: JoinSwarmOptions) {
+    this.disc.add(feed, options);
     this.wrtc.join(feed.discoveryKey);
   }
 

--- a/packages/types/lib/dat.d.ts
+++ b/packages/types/lib/dat.d.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import StrictEventEmitter from 'strict-event-emitter-types';
 import { IHyperdrive } from './hyperdrive';
 import { IReplicableBase } from './replicable';
-import ISwarm from './swarm';
+import ISwarm, { JoinSwarmOptions } from './swarm';
 
 interface IDatEvents {
   join: void;
@@ -12,7 +12,7 @@ interface IDatEvents {
 
 export interface ISwarmable extends StrictEventEmitter<EventEmitter, IDatEvents> {
   isSwarming: boolean;
-  joinSwarm(): Promise<void>;
+  joinSwarm(options?: JoinSwarmOptions): Promise<void>;
   leaveSwarm(): void;
   close(): void;
 }

--- a/packages/types/lib/swarm.d.ts
+++ b/packages/types/lib/swarm.d.ts
@@ -1,13 +1,17 @@
 import { EventEmitter } from 'events';
 import { IReplicable, IReplicableBase } from './replicable';
 
+export type JoinSwarmOptions = {
+  announce?: boolean;
+  lookup?: boolean;
+};
 /**
  * A Swarm is able to find peers and initiate replication with them via the provided
- * data structure's `replicate` method. 
+ * data structure's `replicate` method.
  */
 export default interface ISwarm<T extends IReplicableBase> extends EventEmitter {
-  events?: string[]
-  add(feed: T): void
-  remove(feed: T): void
-  close(): void
+  events?: string[];
+  add(feed: T, options?: JoinSwarmOptions): void;
+  remove(feed: T): void;
+  close(): void;
 }

--- a/packages/types/lib/swarm.d.ts
+++ b/packages/types/lib/swarm.d.ts
@@ -4,6 +4,8 @@ import { IReplicable, IReplicableBase } from './replicable';
 export type JoinSwarmOptions = {
   announce?: boolean;
   lookup?: boolean;
+  upload?: boolean;
+  download?: boolean;
 };
 /**
  * A Swarm is able to find peers and initiate replication with them via the provided

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,9 +822,9 @@
     universal-user-agent "^4.0.0"
 
 "@octokit/rest@^16.28.4":
-  version "16.35.0"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.35.0.tgz#7ccc1f802f407d5b8eb21768c6deca44e7b4c0d8"
-  integrity sha512-9ShFqYWo0CLoGYhA1FdtdykJuMzS/9H6vSbbQWDX4pWr4p9v+15MsH/wpd/3fIU+tSxylaNO48+PIHqOkBRx3w==
+  version "16.35.2"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.35.2.tgz#0098c9e2a895d4afb0fa6578479283553543143c"
+  integrity sha512-iijaNZpn9hBpUdh8YdXqNiWazmq4R1vCUsmxpBB0kCQ0asHZpCx+HNs22eiHuwYKRhO31ZSAGBJLi0c+3XHaKQ==
   dependencies:
     "@octokit/request" "^5.2.0"
     "@octokit/request-error" "^1.0.2"
@@ -900,9 +900,9 @@
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
 "@types/node@*", "@types/node@>= 8", "@types/node@^12.12.14":
-  version "12.12.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.17.tgz#191b71e7f4c325ee0fb23bc4a996477d92b8c39b"
-  integrity sha512-Is+l3mcHvs47sKy+afn2O1rV4ldZFU7W8101cNlOd+MRbjM4Onida8jSZnJdTe/0Pcf25g9BNIUsuugmE6puHA==
+  version "12.12.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.18.tgz#8d16634797d63c2af5bc647ce879f8de20b56469"
+  integrity sha512-DBkZuIMFuAfjJHiunyRc+aNvmXYNwV1IPMgGKGlwCp6zh6MKrVtmvjSWK/axWcD25KJffkXgkfvFra8ndenXAw==
 
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
@@ -1160,7 +1160,7 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-async-limiter@^1.0.0, async-limiter@~1.0.0:
+async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
@@ -1881,9 +1881,9 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js@^2.4.0, core-js@^2.5.0:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
-  integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2358,10 +2358,10 @@ engine.io@~3.4.0:
     engine.io-parser "~2.2.0"
     ws "^7.1.2"
 
-env-paths@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
-  integrity sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=
+env-paths@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
+  integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -2375,10 +2375,10 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.5.1:
-  version "1.16.2"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.16.2.tgz#4e874331645e9925edef141e74fc4bd144669d34"
-  integrity sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==
+es-abstract@^1.17.0-next.1:
+  version "1.17.0-next.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.0-next.1.tgz#94acc93e20b05a6e96dacb5ab2f1cb3a81fc2172"
+  integrity sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==
   dependencies:
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
@@ -2388,6 +2388,7 @@ es-abstract@^1.5.1:
     is-regex "^1.0.4"
     object-inspect "^1.7.0"
     object-keys "^1.1.1"
+    object.assign "^4.1.0"
     string.prototype.trimleft "^2.1.0"
     string.prototype.trimright "^2.1.0"
 
@@ -2557,9 +2558,9 @@ fast-glob@^2.2.6:
     micromatch "^3.1.10"
 
 fast-json-stable-stringify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
-  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fd-lock@^1.0.2:
   version "1.0.2"
@@ -2923,7 +2924,7 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -2949,7 +2950,7 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -3041,7 +3042,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1, has@^1.0.3:
+has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -3163,9 +3164,9 @@ hyperdiscovery@^9.0.0, hyperdiscovery@^9.0.2:
     hypercore-protocol "^6.9.0"
     mutexify "^1.2.0"
 
-"hyperdiscovery@git+https://git@github.com/datproject/hyperdiscovery.git#235a19ef14a8ca702c801f855c6281baa65f9bb4":
+"hyperdiscovery@git+https://git@github.com/sammacbeth/hyperdiscovery.git#39cff7f":
   version "10.2.1"
-  resolved "git+https://git@github.com/datproject/hyperdiscovery.git#235a19ef14a8ca702c801f855c6281baa65f9bb4"
+  resolved "git+https://git@github.com/sammacbeth/hyperdiscovery.git#39cff7fc6428cfabee23d22bf2e3b82ab4552c3d"
   dependencies:
     dat-encoding "^5.0.1"
     dat-swarm-defaults "^1.0.2"
@@ -3544,11 +3545,11 @@ is-promise@^2.1.0:
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
 is-regex@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
-  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
+  integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
   dependencies:
-    has "^1.0.1"
+    has "^1.0.3"
 
 is-ssh@^1.3.0:
   version "1.3.1"
@@ -4463,28 +4464,29 @@ node-gyp-build@^4.1.0:
   integrity sha512-4oiumOLhCDU9Rronz8PZ5S4IvT39H5+JEv/hps9V8s7RSLhsac0TCP78ulnHXOo8X1wdpPiTayGlM1jr4IbnaQ==
 
 node-gyp@^5.0.2:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-5.0.5.tgz#f6cf1da246eb8c42b097d7cd4d6c3ce23a4163af"
-  integrity sha512-WABl9s4/mqQdZneZHVWVG4TVr6QQJZUC6PAx47ITSk9lreZ1n+7Z9mMAIbA3vnO4J9W20P7LhCxtzfWsAD/KDw==
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-5.0.7.tgz#dd4225e735e840cf2870e4037c2ed9c28a31719e"
+  integrity sha512-K8aByl8OJD51V0VbUURTKsmdswkQQusIvlvmTyhHlIT1hBvaSxzdxpSle857XuXa7uc02UEZx9OR5aDxSWS5Qw==
   dependencies:
-    env-paths "^1.0.0"
-    glob "^7.0.3"
-    graceful-fs "^4.1.2"
-    mkdirp "^0.5.0"
-    nopt "2 || 3"
-    npmlog "0 || 1 || 2 || 3 || 4"
-    request "^2.87.0"
-    rimraf "2"
-    semver "~5.3.0"
+    env-paths "^2.2.0"
+    glob "^7.1.4"
+    graceful-fs "^4.2.2"
+    mkdirp "^0.5.1"
+    nopt "^4.0.1"
+    npmlog "^4.1.2"
+    request "^2.88.0"
+    rimraf "^2.6.3"
+    semver "^5.7.1"
     tar "^4.4.12"
-    which "1"
+    which "^1.3.1"
 
-"nopt@2 || 3":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
-  integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
+nopt@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
+  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
   dependencies:
     abbrev "1"
+    osenv "^0.1.4"
 
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5, normalize-package-data@^2.4.0, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -4509,9 +4511,11 @@ normalize-url@^3.3.0:
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
 npm-bundled@^1.0.1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
-  integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
+  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+  dependencies:
+    npm-normalize-package-bin "^1.0.1"
 
 npm-lifecycle@^3.1.2:
   version "3.1.4"
@@ -4527,6 +4531,11 @@ npm-lifecycle@^3.1.2:
     umask "^1.1.0"
     which "^1.3.1"
 
+npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
+  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
+
 "npm-package-arg@^4.0.0 || ^5.0.0 || ^6.0.0", npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-6.1.1.tgz#02168cb0a49a2b75bf988a28698de7b529df5cb7"
@@ -4538,9 +4547,9 @@ npm-lifecycle@^3.1.2:
     validate-npm-package-name "^3.0.0"
 
 npm-packlist@^1.4.4:
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.6.tgz#53ba3ed11f8523079f1457376dd379ee4ea42ff4"
-  integrity sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
+  integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -4561,7 +4570,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -4617,7 +4626,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@4.1.0:
+object.assign@4.1.0, object.assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
   integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
@@ -4628,12 +4637,12 @@ object.assign@4.1.0:
     object-keys "^1.0.11"
 
 object.getownpropertydescriptors@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
-  integrity sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
+  integrity sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
   dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.5.1"
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -4695,7 +4704,7 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@^0.1.5:
+osenv@^0.1.4, osenv@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -5050,9 +5059,9 @@ protoduck@^5.0.1:
     genfun "^5.0.0"
 
 psl@^1.1.24:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.5.0.tgz#47fd1292def7fdb1e138cd78afa8814cebcf7b13"
-  integrity sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA==
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.6.0.tgz#60557582ee23b6c43719d9890fb4170ecd91e110"
+  integrity sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==
 
 pump@^1.0.2, pump@^1.0.3:
   version "1.0.3"
@@ -5170,14 +5179,14 @@ read-cmd-shim@^1.0.1:
     graceful-fs "^4.1.2"
 
 "read-package-json@1 || 2", read-package-json@^2.0.0, read-package-json@^2.0.13:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-2.1.0.tgz#e3d42e6c35ea5ae820d9a03ab0c7291217fc51d5"
-  integrity sha512-KLhu8M1ZZNkMcrq1+0UJbR8Dii8KZUqB0Sha4mOx/bknfKI/fyrQVrG/YIt2UOtG667sD8+ee4EXMM91W9dC+A==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-2.1.1.tgz#16aa66c59e7d4dad6288f179dd9295fd59bb98f1"
+  integrity sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==
   dependencies:
     glob "^7.1.1"
     json-parse-better-errors "^1.0.1"
     normalize-package-data "^2.0.0"
-    slash "^1.0.0"
+    npm-normalize-package-bin "^1.0.0"
   optionalDependencies:
     graceful-fs "^4.1.2"
 
@@ -5331,7 +5340,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.87.0:
+request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -5414,7 +5423,7 @@ retry@^0.10.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
-rimraf@2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -5474,7 +5483,7 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -5483,11 +5492,6 @@ semver@^6.0.0, semver@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@~5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -5535,7 +5539,7 @@ signed-varint@^2.0.1:
   dependencies:
     varint "~5.0.0"
 
-simple-peer@^9.2.0:
+simple-peer@^9.6.2:
   version "9.6.2"
   resolved "https://registry.yarnpkg.com/simple-peer/-/simple-peer-9.6.2.tgz#42418e77cf8f9184e4fa22ef1017b195c2bf84d7"
   integrity sha512-EOKoImCaqtNvXIntxT1CBBK/3pVi7tMAoJ3shdyd9qk3zLm3QPiRLb/sPC1G2xvKJkJc5fkQjCXqRZ0AknwTig==
@@ -5554,15 +5558,15 @@ simple-sha1@^2.1.0:
     rusha "^0.8.1"
 
 simple-signal-client@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/simple-signal-client/-/simple-signal-client-2.3.0.tgz#f32c3eba2299711551a0e1f8299a68be61262be9"
-  integrity sha512-A4oXLm7jK1E8byZhuRvdZJwqCA/tsLDFI2agNzQPbS/RT0LULlZNdAu3GH3GPolOnfaFtt5cEldc7vNGngTWDg==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/simple-signal-client/-/simple-signal-client-2.3.1.tgz#4060db193236ac7497c442d9c8397924e912cbef"
+  integrity sha512-G1w2Ya4+scKah6mXkU6EZogo896uobgcnnWqgqYN1vJsF6o5IAjj9ZNSuoj82F9CNPSPKazie3Wmv+0eNYkVGQ==
   dependencies:
     babel-polyfill "^6.23.0"
     cuid "^2.0.2"
     inherits "^2.0.3"
     nanobus "^4.3.3"
-    simple-peer "^9.2.0"
+    simple-peer "^9.6.2"
 
 simple-signal-server@^2.1.1:
   version "2.1.1"
@@ -5578,11 +5582,6 @@ siphash24@^1.0.1:
   integrity sha512-dKKwjIoTOa587TARYLlBRXq2lkbu5Iz35XrEVWpelhBP1m8r2BGOy1QlaZe84GTFHG/BTucEUd2btnNc8QzIVA==
   dependencies:
     nanoassert "^1.0.0"
-
-slash@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
-  integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
 slash@^2.0.0:
   version "2.0.0"
@@ -5899,9 +5898,9 @@ stream-equal@^1.0.0:
     "@types/node" "*"
 
 stream-shift@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
-  integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
+  integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
 strict-event-emitter-types@^2.0.0:
   version "2.0.0"
@@ -6304,9 +6303,9 @@ typescript@^3.7.2, typescript@^3.7.3:
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 uglify-js@^3.1.4:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.1.tgz#35c7de17971a4aa7689cd2eae0a5b39bb838c0c5"
-  integrity sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.2.tgz#cb1a601e67536e9ed094a92dd1e333459643d3f9"
+  integrity sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==
   dependencies:
     commander "~2.20.3"
     source-map "~0.6.1"
@@ -6557,7 +6556,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@1, which@1.3.1, which@^1.2.9, which@^1.3.1:
+which@1.3.1, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -6648,11 +6647,9 @@ ws@^3.2.0:
     ultron "~1.1.0"
 
 ws@^7.1.2:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.0.tgz#422eda8c02a4b5dba7744ba66eebbd84bcef0ec7"
-  integrity sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==
-  dependencies:
-    async-limiter "^1.0.0"
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.1.tgz#03ed52423cd744084b2cf42ed197c8b65a936b8e"
+  integrity sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==
 
 ws@~6.1.0:
   version "6.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,19 +3151,6 @@ hypercore@^7.5.0:
   optionalDependencies:
     fd-lock "^1.0.2"
 
-hyperdiscovery@^10.2.1:
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/hyperdiscovery/-/hyperdiscovery-10.2.1.tgz#1a8907c96a9faff07f785d31be181c4d30b01b75"
-  integrity sha512-r3rBOLOfkREh+yaPcu/6B6itNL+g+/7YqXOPGTbxJUEQuC9JmORerkD2lZic+x4ELjxbUOx95NHYNqsG67paSA==
-  dependencies:
-    dat-encoding "^5.0.1"
-    dat-swarm-defaults "^1.0.2"
-    debug "^4.1.1"
-    discovery-swarm "^5.1.4"
-    discovery-swarm-web "^2.0.0"
-    hypercore-protocol "^6.9.0"
-    mutexify "^1.2.0"
-
 hyperdiscovery@^9.0.0, hyperdiscovery@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/hyperdiscovery/-/hyperdiscovery-9.0.2.tgz#2ce2f9abf37cf0f50c013f8a08ece4038cb8956b"
@@ -3173,6 +3160,18 @@ hyperdiscovery@^9.0.0, hyperdiscovery@^9.0.2:
     dat-swarm-defaults "^1.0.2"
     debug "^4.1.1"
     discovery-swarm "^5.1.4"
+    hypercore-protocol "^6.9.0"
+    mutexify "^1.2.0"
+
+"hyperdiscovery@git+https://git@github.com/datproject/hyperdiscovery.git#235a19ef14a8ca702c801f855c6281baa65f9bb4":
+  version "10.2.1"
+  resolved "git+https://git@github.com/datproject/hyperdiscovery.git#235a19ef14a8ca702c801f855c6281baa65f9bb4"
+  dependencies:
+    dat-encoding "^5.0.1"
+    dat-swarm-defaults "^1.0.2"
+    debug "^4.1.1"
+    discovery-swarm "^5.1.4"
+    discovery-swarm-web "^2.0.0"
     hypercore-protocol "^6.9.0"
     mutexify "^1.2.0"
 


### PR DESCRIPTION
Improves control of networking by allowing the `announce` option when joining. This means that the IP address will not be listed as a peer for the dat. The client will not receive incoming connections.