### PR TITLE
Use a single corestore for all drives.

### DIFF
--- a/packages/dat2/lib/index.ts
+++ b/packages/dat2/lib/index.ts
@@ -3,10 +3,10 @@ import { Hyperdrive10 } from '@sammacbeth/dat-types/lib/hyperdrive10';
 import { IReplicableNoise } from '@sammacbeth/dat-types/lib/replicable';
 import ISwarm, { JoinSwarmOptions } from '@sammacbeth/dat-types/lib/swarm';
 import { EventEmitter } from 'events';
-import HypercoreProtocol = require('hypercore-protocol');
 import hyperdrive10Impl = require('hyperdrive');
-import hyperswarm = require('hyperswarm');
-import pump = require('pump');
+import Corestore = require('corestore');
+import ram = require('random-access-memory');
+import SwarmNetworker = require('corestore-swarm-networking');
 
 export type HyperswarmOpts = {
   bootstrap?: string[];
@@ -25,76 +25,54 @@ export type CoreStoreOpts = {
 
 class HyperSwarm<T extends IReplicableNoise> extends EventEmitter implements ISwarm<T> {
   private swarm: any;
-  private feeds = new Map<string, [IReplicableNoise, JoinSwarmOptions]>();
+  private ready: Promise<void>
 
-  constructor(opts?: HyperswarmOpts) {
+  constructor(loader: CorestoreLoader, opts?: HyperswarmOpts) {
     super();
-    this.swarm = hyperswarm(opts);
-    this.swarm.on('connection', (connection, info) => {
-      if (info.peer && this.feeds.has(info.peer.topic.toString('hex'))) {
-        // if peer is provided we can replicate directly
-        const [feed, feedOpts] = this.feeds.get(info.peer.topic.toString('hex'));
-        const stream = feed.replicate(!!info.client, feedOpts);
-        pump(connection, stream, connection);
-      } else {
-        const stream = new HypercoreProtocol(!!info.client, { live: true, encrypt: true });
-        stream.on('handshake', () => {
-          const deduped = info.deduplicate(stream.publicKey, stream.remotePublicKey);
-          if (deduped) {
-            return;
-          }
-          stream.on('discovery-key', (dbuf: Buffer) => {
-            const dkey = dbuf.toString('hex');
-            if (this.feeds.has(dkey)) {
-              const [feed, feedOpts] = this.feeds.get(dkey);
-              // TODO: can we do this with a public API?
-              (feed as any).corestore.replicate(!!info.client, {
-                ...feedOpts,
-                stream,
-              });
-            }
-          });
-        });
-        pump(connection, stream, connection);
-      }
-    });
+    this.ready = new Promise(async (resolve) => {
+      await loader.ready;
+      this.swarm = new SwarmNetworker(loader.corestore, opts);
+      resolve();
+    })
   }
 
   public async add(feed: IReplicableNoise, options: JoinSwarmOptions = {}) {
     const { announce = false, lookup = true, upload = true, download = true } = options;
     const opts = { announce, lookup, upload, download };
-    feed.ready(() => {
-      this.swarm.join(feed.discoveryKey, opts);
-    });
-    this.feeds.set(feed.discoveryKey.toString('hex'), [feed, opts]);
+    await this.ready;
+    await this.swarm.join(feed.discoveryKey, opts);
   }
 
   public remove(feed: IReplicableNoise) {
     this.swarm.leave(feed.discoveryKey);
-    this.feeds.delete(feed.discoveryKey.toString('hex'));
   }
 
   public close() {
-    return this.swarm.destroy();
+    return this.swarm.close();
   }
 }
 
 class CorestoreLoader extends DatLoaderBase<Hyperdrive10> {
   public corestore: any;
-  public tmpstore: any;
+  public ready: Promise<void>
 
   constructor(opts: StorageOpts & HyperswarmOpts) {
     super({
       hyperdriveFactory: (storage, key, driveOpts) => {
-        return hyperdrive10Impl(storage, key, driveOpts);
+        return hyperdrive10Impl(this.corestore, key, driveOpts);
       },
-      swarmFactory: () => new HyperSwarm(opts),
+      swarmFactory: () => new HyperSwarm(this, opts),
       ...opts,
     });
-  }
-
-  public suspend(): void {
-    super.suspend();
+    this.ready = new Promise(async (resolve) => {
+      if (opts.persistantStorageFactory) {
+        const storage = await opts.persistantStorageFactory('default');
+        this.corestore = new Corestore(storage, opts);
+      } else {
+        this.corestore = new Corestore(ram, opts);
+      }
+      resolve();
+    })
   }
 }
 

--- a/packages/dat2/package.json
+++ b/packages/dat2/package.json
@@ -34,10 +34,8 @@
     "@sammacbeth/dat-api-core": "^0.7.0",
     "@sammacbeth/dat-types": "^0.7.0",
     "corestore": "^5.3.2",
-    "hypercore-protocol": "^8.0.0",
-    "hyperdrive": "^10.10.3",
-    "hyperswarm": "^2.14.0",
-    "pump": "^3.0.0"
+    "corestore-swarm-networking": "^5.4.2",
+    "hyperdrive": "^10.10.3"
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2334,6 +2334,18 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+corestore-swarm-networking@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/corestore-swarm-networking/-/corestore-swarm-networking-5.4.2.tgz#bfce6a7dede51f5c5d4ba3613b4244ca02b3bb38"
+  integrity sha512-6Iu4o7eXSW6PnR8FU4k2ttKLG9UpV5pJVevGStZeWZp2jZSqnCW4I7HykiKmyzHoB3Ug5Q7xwySFwoGl9pFuxg==
+  dependencies:
+    dat-encoding "^5.0.1"
+    debug "^4.1.1"
+    end-of-stream "^1.4.4"
+    hypercore-protocol "^8.0.0"
+    hyperswarm "^2.10.0"
+    pump "^3.0.0"
+
 corestore@^5.0.0, corestore@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/corestore/-/corestore-5.3.2.tgz#b0cc9719b14198526b69cdb414e0f424f5cfd825"
@@ -4039,7 +4051,7 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-hyperswarm@^2.14.0:
+hyperswarm@^2.10.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/hyperswarm/-/hyperswarm-2.14.0.tgz#325357c78cabec76e3e0bb109470bf760c6fafe2"
   integrity sha512-vJI6vVH0/PjlCVdRJLXr1an0guRSYRE1uE5wnEUmgjp4erYBIOALn+0YR/W95fTCZfp9Y+YA2Ku9npo87/tqqg==


### PR DESCRIPTION
Changes the dat2 api behaviour to store all data in a single corestore. This has a couple of implications:
 1. We can use `corestore-swarm-networker` for swarming rather than maintain our own replication implementation.
 2. Mounts will get auto-deduplicated.

This unfortunately messes with drive deletion, as cores are no longer separated by namespace in storage. Corestore data pruning is still any open issue anyway, as with mounts it is difficult to know if it is safe to delete a core or not.